### PR TITLE
Move private components

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,12 @@
 
 This is Atom's UI library. Originally forked from Bootstrap `3.3.6` then tweaked to Atom's needy needs.
 
+
 ## Components
 
-Open the Styleguide (`cmd-ctrl-shift-g`) to see them in action.
+Here a list of [all components](https://github.com/atom/atom-ui/blob/master/atom-ui.less). Open the Styleguide package (`cmd-ctrl-shift-g`) to see them in action and how to use them.
 
-- Alerts
-- Badges
-- Button Group
-- Buttons
-- Code
-- Forms
-- Icons
-- Links
-- Lists
-- Markdown
-- Messages
-- Navs
-- Popover-list
-- Scaffolding
-- Select-list
-- Tables
-- Text
-- Tooltip
-- Utilities
 
-> __Note__: Currently not all components listed here are in the Styleguide. We're still in the process of adding official support for those that aren't.
+## Feature requests
+
+If you need something, feel free to open an issue and it might can be added. :sign_of_horns:

--- a/atom-ui.less
+++ b/atom-ui.less
@@ -1,26 +1,28 @@
 // Atom UI
 
-@import "styles/scaffolding.less";
-
 // Private! Don't use these in packages.
 // If you need something, feel free to open an issue and it might can be made public
+@import "styles/private/scaffolding.less";
+
+@import "styles/private/alerts.less";
+@import "styles/private/code.less";
+@import "styles/private/forms.less";
+@import "styles/private/links.less";
+@import "styles/private/navs.less";
 @import "styles/private/sections.less";
+@import "styles/private/tables.less";
+@import "styles/private/utilities.less";
 
 // Public components
-@import "styles/alerts.less";
+// Open the Styleguide to see them in action
+
 @import "styles/badges.less";
 @import "styles/button-groups.less";
 @import "styles/buttons.less";
-@import "styles/code.less";
-@import "styles/forms.less";
 @import "styles/icons.less";
 @import "styles/layout.less";
-@import "styles/links.less";
 @import "styles/lists.less";
 @import "styles/messages.less";
-@import "styles/navs.less";
 @import "styles/select-list.less";
-@import "styles/tables.less";
 @import "styles/text.less";
 @import "styles/tooltip.less";
-@import "styles/utilities.less";

--- a/atom-ui.less
+++ b/atom-ui.less
@@ -13,9 +13,9 @@
 @import "styles/private/tables.less";
 @import "styles/private/utilities.less";
 
+
 // Public components
 // Open the Styleguide to see them in action
-
 @import "styles/badges.less";
 @import "styles/button-groups.less";
 @import "styles/buttons.less";

--- a/styles/private/README.md
+++ b/styles/private/README.md
@@ -1,0 +1,5 @@
+# Private components
+
+> Private! Don't use these in packages.
+
+If you need something, feel free to open an issue and it might can be made public.

--- a/styles/private/alerts.less
+++ b/styles/private/alerts.less
@@ -1,4 +1,4 @@
-@import "variables/variables";
+@import "../variables/variables";
 @import "ui-variables";
 
 //

--- a/styles/private/code.less
+++ b/styles/private/code.less
@@ -1,4 +1,4 @@
-@import "variables/variables";
+@import "../variables/variables";
 @import "ui-variables";
 
 //

--- a/styles/private/forms.less
+++ b/styles/private/forms.less
@@ -1,6 +1,6 @@
-@import "variables/variables";
+@import "../variables/variables";
 @import "ui-variables";
-@import "mixins/mixins";
+@import "../mixins/mixins";
 
 //
 // Forms

--- a/styles/private/links.less
+++ b/styles/private/links.less
@@ -1,5 +1,5 @@
 @import "ui-variables";
-@import "mixins/mixins";
+@import "../mixins/mixins";
 
 // Links
 

--- a/styles/private/navs.less
+++ b/styles/private/navs.less
@@ -1,6 +1,6 @@
-@import "variables/variables";
+@import "../variables/variables";
 @import "ui-variables";
-@import "mixins/mixins";
+@import "../mixins/mixins";
 
 //
 // Navs

--- a/styles/private/scaffolding.less
+++ b/styles/private/scaffolding.less
@@ -1,6 +1,6 @@
-@import "variables/variables";
+@import "../variables/variables";
 @import "ui-variables";
-@import "mixins/mixins";
+@import "../mixins/mixins";
 
 //
 // Scaffolding

--- a/styles/private/tables.less
+++ b/styles/private/tables.less
@@ -1,4 +1,4 @@
-@import "variables/variables";
+@import "../variables/variables";
 @import "ui-variables";
 
 //

--- a/styles/private/utilities.less
+++ b/styles/private/utilities.less
@@ -1,5 +1,5 @@
 @import "ui-variables";
-@import "mixins/mixins";
+@import "../mixins/mixins";
 
 // Toggling content
 // -------------------------


### PR DESCRIPTION
These components aren't currently shown in the Styleguide. This PR moves them to a `private` folder to make that more clear.
