### PR TITLE
Add more Styleguide support

### DIFF
--- a/atom-ui.less
+++ b/atom-ui.less
@@ -24,6 +24,8 @@
 @import "styles/layout.less";
 @import "styles/lists.less";
 @import "styles/messages.less";
+@import "styles/modals.less";
+@import "styles/panels.less";
 @import "styles/select-list.less";
 @import "styles/site-colors.less";
 @import "styles/text.less";

--- a/atom-ui.less
+++ b/atom-ui.less
@@ -25,5 +25,6 @@
 @import "styles/lists.less";
 @import "styles/messages.less";
 @import "styles/select-list.less";
+@import "styles/site-colors.less";
 @import "styles/text.less";
 @import "styles/tooltip.less";

--- a/atom-ui.less
+++ b/atom-ui.less
@@ -23,6 +23,7 @@
 @import "styles/icons.less";
 @import "styles/layout.less";
 @import "styles/lists.less";
+@import "styles/loading.less";
 @import "styles/messages.less";
 @import "styles/modals.less";
 @import "styles/panels.less";

--- a/atom-ui.less
+++ b/atom-ui.less
@@ -19,6 +19,7 @@
 @import "styles/badges.less";
 @import "styles/button-groups.less";
 @import "styles/buttons.less";
+@import "styles/git-status.less";
 @import "styles/icons.less";
 @import "styles/layout.less";
 @import "styles/lists.less";

--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -56,6 +56,7 @@
   &.selected:hover {
     // we want the selected button to behave like the :hover button; it's on top of the other buttons.
     z-index: 1;
+    color: @text-color-selected;
     background-color: @button-background-color-selected;
   }
 

--- a/styles/git-status.less
+++ b/styles/git-status.less
@@ -1,0 +1,13 @@
+@import "ui-variables";
+
+//
+// Git Status
+// --------------------------------------------------
+
+.status {
+  &-ignored  { color: @text-color-subtle; }
+  &-added    { color: @text-color-success; }
+  &-modified { color: @text-color-warning; }
+  &-removed  { color: @text-color-error; }
+  &-renamed  { color: @text-color-info; }
+}

--- a/styles/loading.less
+++ b/styles/loading.less
@@ -1,0 +1,21 @@
+//
+// Loading
+// --------------------------------------------------
+
+.loading-spinner(@size) {
+  display: block;
+  width: @size;
+  height: @size;
+  background-image: url(images/octocat-spinner-128.gif);
+  background-repeat: no-repeat;
+  background-size: cover;
+
+  &.inline-block {
+    display: inline-block;
+  }
+}
+
+.loading-spinner-tiny   { .loading-spinner(16px); }
+.loading-spinner-small  { .loading-spinner(32px); }
+.loading-spinner-medium { .loading-spinner(48px); }
+.loading-spinner-large  { .loading-spinner(64px); }

--- a/styles/modals.less
+++ b/styles/modals.less
@@ -1,0 +1,82 @@
+
+//
+// Modals
+// --------------------------------------------------
+
+.overlay, // deprecated .overlay
+atom-panel.modal {
+  position: absolute;
+  display: block;
+  top: 0;
+  left: 50%;
+  width: 500px;
+  margin-left: -250px;
+  z-index: 9999;
+  box-sizing: border-box;
+  border-top: none;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+
+  color: @text-color;
+  background-color: @overlay-background-color;
+
+  padding: 10px;
+
+  // shrink modals when window gets narrow
+  @media (max-width: 500px) {
+    & {
+      width: 100%;
+      left: 0;
+      margin-left: 0;
+    }
+  }
+
+  h1 {
+    margin-top: 0;
+    color: @text-color-highlight;
+    font-size: 1.6em;
+    font-weight: bold;
+  }
+
+  h2 {
+    font-size: 1.3em;
+  }
+
+  atom-text-editor[mini] {
+    margin-bottom: 10px;
+  }
+
+  .message {
+    padding-top: 5px;
+    font-size: 11px;
+  }
+
+  &.mini {
+    width: 200px;
+    margin-left: -100px;
+    font-size: 12px;
+  }
+}
+
+
+// Deprecated: overlay, from-top, from-bottom, floating
+// --------------------------------------------------
+// TODO: Remove these!
+
+.overlay.from-top {
+  top: 0;
+  border-top: none;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.overlay.from-bottom {
+  bottom: 0;
+  border-bottom: none;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.overlay.floating {
+  left: auto;
+}

--- a/styles/panels.less
+++ b/styles/panels.less
@@ -1,0 +1,36 @@
+//
+// Panels
+// --------------------------------------------------
+
+.tool-panel, // deprecated: .tool-panel
+.panel, // deprecated: .panel
+atom-panel {
+  background-color: @tool-panel-background-color;
+}
+
+.inset-panel {
+  border-radius: @component-border-radius;
+  background-color: @inset-panel-background-color;
+}
+
+.panel-heading {
+  margin: 0;
+  padding: @component-padding;
+  border-radius: 0;
+  font-size: @font-size;
+  line-height: 1;
+  background-color: @panel-heading-background-color;
+
+  .inset-panel & {
+    border-radius: @component-border-radius @component-border-radius 0 0;
+  }
+
+  .btn {
+    @btn-height: @component-line-height - 5px;
+    height: @btn-height;
+    line-height: @btn-height;
+    font-size: @font-size - 2px;
+    position: relative;
+    top: -5px;
+  }
+}

--- a/styles/select-list.less
+++ b/styles/select-list.less
@@ -47,6 +47,7 @@
   min-width: 200px;
   margin-left: 0;
   position: relative;
+  background-color: @overlay-background-color;
 
   ol.list-group {
     position: relative;

--- a/styles/select-list.less
+++ b/styles/select-list.less
@@ -1,5 +1,6 @@
 @import "ui-variables";
 @import "octicon-mixins";
+@import "mixins/mixins";
 
 .select-list {
   .loading {
@@ -28,6 +29,7 @@
 
     li {
       display: block;
+      .clearfix();
 
       .primary-line,
       .secondary-line {
@@ -36,6 +38,10 @@
         overflow: hidden;
       }
     }
+  }
+
+  .status {
+    float: right;
   }
 }
 
@@ -53,5 +59,11 @@
     position: relative;
     overflow-y: scroll;
     max-height: 200px;
+    margin-top: 0;
+  }
+
+  li {
+    padding-left: @component-padding;
+    padding-right: @component-padding;
   }
 }

--- a/styles/site-colors.less
+++ b/styles/site-colors.less
@@ -1,0 +1,9 @@
+//
+// Site colors
+// --------------------------------------------------
+
+.ui-site-1 { background-color: @ui-site-color-1; }
+.ui-site-2 { background-color: @ui-site-color-2; }
+.ui-site-3 { background-color: @ui-site-color-3; }
+.ui-site-4 { background-color: @ui-site-color-4; }
+.ui-site-5 { background-color: @ui-site-color-5; }

--- a/styles/text.less
+++ b/styles/text.less
@@ -118,6 +118,7 @@ p {
 // -------------------------
 
 // Ex: (12px small font / 14px base font) * 100% = about 85%
+.text-smaller,
 small,
 .small {
   font-size: floor((100% * @font-size-small / @font-size-base));
@@ -141,24 +142,15 @@ mark,
 .text-uppercase      { text-transform: uppercase; }
 .text-capitalize     { text-transform: capitalize; }
 
+// text-classes
+.text-subtle, .text-muted { color: @text-color-subtle; }
+.text-highlight           { color: @text-color-highlight; }
+
 // Contextual colors
-.text-muted {
-  color: @text-muted;
-}
-.text-info,
-.text-primary {
-  .text-variant(info);
-}
-.text-success {
-  .text-variant(success);
-}
-.text-warning {
-  .text-variant(warning);
-}
-.text-error,
-.text-danger {
-  .text-variant(error);
-}
+.text-info, .text-primary { .text-variant(info); }
+.text-success             { .text-variant(success); }
+.text-warning             { .text-variant(warning); }
+.text-error, .text-danger { .text-variant(error); }
 
 // Contextual backgrounds
 // For now we'll leave these alongside the text classes until v4 when we can
@@ -182,6 +174,34 @@ mark,
   .bg-variant(@state-danger-bg);
 }
 
+
+// Highlight
+// -------------------------
+
+.highlight() {
+  padding: 0 .4em;
+  font-weight: bold;
+  border-radius: @component-border-radius;
+}
+
+.highlight {
+  .highlight();
+  color: @text-color-highlight;
+  background-color: @background-color-highlight;
+}
+
+.highlight-color(@name, @color) {
+  .highlight-@{name} {
+    .highlight();
+    color: #fff;
+    background-color: fadeout(@color, 50%);
+  }
+}
+
+.highlight-color(info,    @background-color-info);
+.highlight-color(warning, @background-color-warning);
+.highlight-color(error,   @background-color-error);
+.highlight-color(success, @background-color-success);
 
 
 // Lists


### PR DESCRIPTION
This adds some components that can be found in the Styleguide but rely currently on themes to be styled. This is ok if themes keep getting forked, but if a theme removes some styles, it could look broken/unstyled when used in packages. This PR adds at least some basic styling.
