### PR TITLE
New inputs + controls

### DIFF
--- a/atom-ui.less
+++ b/atom-ui.less
@@ -22,6 +22,7 @@
 @import "styles/buttons.less";
 @import "styles/git-status.less";
 @import "styles/icons.less";
+@import "styles/inputs.less";
 @import "styles/layout.less";
 @import "styles/lists.less";
 @import "styles/loading.less";

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -2,6 +2,7 @@
 
 @component-size: @component-icon-size; // use for text-less controls like radio, checkboxes etc.
 @text-component-height: 2em;
+@component-background-color: mix(@text-color, @base-background-color, 20%);
 
 //
 // Text Inputs
@@ -60,7 +61,7 @@
   vertical-align: middle;
   font-size: inherit;
   border-radius: 50%;
-  background-color: @text-color-subtle;
+  background-color: @component-background-color;
   transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
 
   && { margin: 0 .5em 0 0; } // override bootstrap
@@ -105,7 +106,7 @@
   vertical-align: middle;
   font-size: inherit;
   border-radius: @component-border-radius;
-  background-color: @text-color-subtle;
+  background-color: @component-background-color;
   transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
 
   && { margin: 0 .5em 0 0; } // override bootstrap
@@ -144,7 +145,7 @@
   &:checked {
     background-color: @background-color-info;
     &:active {
-      background-color: @text-color-subtle;
+      background-color: @component-background-color;
     }
     &:before {
       opacity: 1;
@@ -161,7 +162,7 @@
   &:indeterminate {
     background-color: @background-color-info;
     &:active {
-      background-color: @text-color-subtle;
+      background-color: @component-background-color;
     }
     &:after {
       opacity: 1;
@@ -184,7 +185,7 @@
   width: @component-size * 2;
   height: @component-size;
   border-radius: 2em;
-  background-color: @text-color-subtle;
+  background-color: @component-background-color;
   transition: background-color .2s cubic-bezier(0.5, 0.15, 0.2, 1);
 
   && { margin: 0; } // override bootstrap
@@ -226,8 +227,7 @@
   margin: @component-padding 0;
   height: 4px;
   border-radius: @component-border-radius;
-  border: 1px solid @input-border-color;
-  background-color: @input-background-color;
+  background-color: @component-background-color;
   &::-webkit-slider-thumb {
     -webkit-appearance: none;
     width: @component-size;
@@ -253,11 +253,11 @@
   width: @component-size * 2.5;
   height: @component-size * 2.5;
   border-radius: 50%;
-  border: 5px solid @input-border-color;
+  border: 2px solid @input-border-color;
   background-color: @input-background-color;
   &::-webkit-color-swatch-wrapper { padding: 0; }
   &::-webkit-color-swatch {
-    border: 1px solid hsla(0,0%,0%,.2);
+    border: 1px solid hsla(0,0%,0%,.1);
     border-radius: 50%;
     transition: transform .16s cubic-bezier(0.5, 0.15, 0.2, 1);
     &:active {

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -284,7 +284,7 @@
 // Select
 // -------------------------
 
-.select {
+.input-select {
   height: calc(@text-component-height ~'+' 2px); // + 2px? Magic!
   border-radius: @component-border-radius;
   border: 1px solid @button-border-color;

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -46,16 +46,23 @@
 .input-number {
   position: relative;
   width: auto;
-  padding-right: 20px; // space for the spin-button
+  padding-right: 1.2em; // space for the spin button
   &::-webkit-inner-spin-button {
-    -webkit-appearance: menulist;
+    -webkit-appearance: menulist-button;
     position: absolute;
-    top: 0;
-    bottom: 0;
-    right: 0;
-    width: 16px;
-    border-right: 4px solid @input-background-color; // a bit more padding
-    background-color: @input-background-color;
+    top: 1px;
+    bottom: 1px;
+    right: 1px;
+    width: calc(.6em ~'+' 9px); // magic numbers, OMG!
+    outline: 1px solid @input-background-color;
+    outline-offset: -1px; // reduces border radius (that can't be changed)
+    border-right: .2em solid @background-color-highlight; // a bit more padding
+    background-color: @background-color-highlight;
+    transition: transform .16s cubic-bezier(0.5, 0.15, 0.2, 1);
+    &:active {
+      transform: scale(.9);
+      transition-duration: 0s;
+    }
   }
 }
 

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -20,20 +20,10 @@ input.input-toggle {
 }
 
 //
-// Text Inputs
+// Mixins
 // -------------------------
 
-.input-text,
-.input-search,
-.input-textarea {
-  display: block;
-  width: 100%;
-}
-
-.input-text,
-.input-search,
-.input-number,
-.input-textarea {
+.input-field-mixin() {
   padding: .25em .4em;
   line-height: 1.5; // line-height + padding = @text-component-height
   border-radius: @component-border-radius;
@@ -48,15 +38,42 @@ input.input-toggle {
   }
 }
 
+.input-block-mixin() {
+  display: block;
+  width: 100%;
+}
+
+
+//
+// Text
+// -------------------------
+
+.input-text {
+  .input-block-mixin();
+  .input-field-mixin();
+}
+
 
 //
 // Search
 // -------------------------
 
 .input-search {
+  .input-block-mixin();
+  .input-field-mixin();
   &&::-webkit-search-cancel-button {
     -webkit-appearance: searchfield-cancel-button;
   }
+}
+
+
+//
+// Text Area
+// -------------------------
+
+.input-textarea {
+  .input-block-mixin();
+  .input-field-mixin();
 }
 
 
@@ -65,6 +82,7 @@ input.input-toggle {
 // -------------------------
 
 .input-number {
+  .input-field-mixin();
   position: relative;
   width: auto;
   padding-right: 1.2em; // space for the spin button

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -110,7 +110,7 @@ input.input-toggle {
     width: inherit;
     height: inherit;
     border-radius: inherit;
-    border: @component-size/4 solid transparent;
+    border: @component-size/3 solid transparent;
     background-clip: content-box;
     background-color: @base-background-color;
     transform: scale(0);

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -1,5 +1,8 @@
 @import "ui-variables";
 
+@component-size: @component-icon-size; // use for text-less controls like radio, checkboxes etc.
+@text-component-height: 2em;
+
 //
 // Text Inputs
 // -------------------------
@@ -9,7 +12,8 @@
 .input-number,
 .input-textarea {
   width: 150px;
-  padding: @component-padding/4 @component-padding/2;
+  padding: .25em .4em;
+  line-height: 1.5; // line-height + padding = @text-component-height
   border-radius: @component-border-radius;
   border: 1px solid @input-border-color;
   background-color: @input-background-color;
@@ -51,14 +55,15 @@
   -webkit-appearance: none;
   display: inline-block;
   position: relative;
-  width: 1.125em;
-  height: 1.125em;
-  margin: 0 .5em 0 0; // Bootstrap override
+  width: @component-size;
+  height: @component-size;
   vertical-align: middle;
   font-size: inherit;
-  border-radius: 1.125em;
+  border-radius: 50%;
   background-color: @text-color-subtle;
   transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
+
+  && { margin: 0 .5em 0 0; } // override bootstrap
 
   &:before {
     content: "";
@@ -66,6 +71,8 @@
     width: inherit;
     height: inherit;
     border-radius: inherit;
+    border: @component-size/4 solid transparent;
+    background-clip: content-box;
     background-color: @base-background-color;
     transform: scale(0);
     transition: transform .1s cubic-bezier(0.5, 0.15, 0.2, 1);
@@ -79,7 +86,7 @@
   &:checked {
     background-color: @background-color-info;
     &:before {
-      transform: scale(.5);
+      transform: scale(1);
     }
   }
 }
@@ -93,18 +100,18 @@
   -webkit-appearance: none;
   display: inline-block;
   position: relative;
-  width: 1.125em;
-  height: 1.125em;
-  margin: 0 .5em 0 0; // Bootstrap override
+  width: @component-size;
+  height: @component-size;
   vertical-align: middle;
   font-size: inherit;
   border-radius: @component-border-radius;
   background-color: @text-color-subtle;
   transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
 
-  &:focus {
-    outline: 0;
-    box-shadow: 0 0 0 1px @base-border-color;
+  && { margin: 0 .5em 0 0; } // override bootstrap
+
+  &&:focus {
+    outline: 0; // TODO: Add it back
   }
   &:active {
     background-color: @background-color-info;
@@ -114,11 +121,9 @@
   &:after {
     content: "";
     position: absolute;
-    top: .85em;
-    left: .425em;
-    height: .125em;
-    min-height: 2px;
-    max-height: 5px;
+    top: @component-size * .75;
+    left: @component-size * .4;
+    height: 2px;
     border-radius: 1px;
     background-color: @base-background-color;
     transform-origin: 0 0;
@@ -126,11 +131,11 @@
     transition: transform .1s cubic-bezier(0.5, 0.15, 0.2, 1), opacity .1s cubic-bezier(0.5, 0.15, 0.2, 1);
   }
   &:before {
-    width: .35em;
+    width: @component-size * .33;
     transform: translate3d(0,0,0) rotate(225deg) scale(0);
   }
   &:after {
-    width: .7em;
+    width: @component-size * .66;
     margin: -1px;
     transform: translate3d(0,0,0) rotate(-45deg) scale(0);
     transition-delay: .05s;
@@ -160,7 +165,7 @@
     }
     &:after {
       opacity: 1;
-      transform: translate3d(-.125em, -.25em, 0) rotate(0deg) scale(1);
+      transform: translate3d(@component-size * -.14, @component-size * -.25, 0) rotate(0deg) scale(1);
       transition-delay: 0;
     }
   }
@@ -176,13 +181,15 @@
   display: inline-block;
   position: relative;
   font-size: inherit;
-  margin: 0 0 0 -3.5em;
-  width: 2.8em;
-  height: 1.4em;
+  width: @component-size * 2;
+  height: @component-size;
   border-radius: 2em;
   background-color: @text-color-subtle;
-  transition: background-color 0.2s cubic-bezier(0.5, 0.15, 0.2, 1);
-  &.input-toggle:focus {
+  transition: background-color .2s cubic-bezier(0.5, 0.15, 0.2, 1);
+
+  && { margin: 0; } // override bootstrap
+
+  &&:focus {
     outline: 0;
   }
   &:checked {
@@ -193,13 +200,13 @@
   &:before {
     content: "";
     position: absolute;
-    width: 1.4em;
-    height: inherit;
+    width: @component-size;
+    height: @component-size;
     border-radius: inherit;
-    border: 4px solid transparent;
+    border: @component-size/4 solid transparent;
     background-clip: content-box;
     background-color: @base-background-color;
-    transition: transform 0.2s cubic-bezier(0.5, 0.15, 0.2, 1);
+    transition: transform .2s cubic-bezier(0.5, 0.15, 0.2, 1);
   }
   &:active:before {
     opacity: .5;
@@ -223,9 +230,9 @@
   background-color: @input-background-color;
   &::-webkit-slider-thumb {
     -webkit-appearance: none;
-    width: 1.25em;
-    height: 1.25em;
-    border-radius: 1em;
+    width: @component-size;
+    height: @component-size;
+    border-radius: 50%;
     background-color: @background-color-info;
     transition: transform .16s;
     &:active {
@@ -242,18 +249,21 @@
 
 .input-color {
   -webkit-appearance: none;
-  padding: 4px;
-  width: 3em;
-  height: 3em;
-  border-radius: 3em;
-  border: 1px solid @input-border-color;
+  padding: 0;
+  width: @component-size * 2.5;
+  height: @component-size * 2.5;
+  border-radius: 50%;
+  border: 5px solid @input-border-color;
   background-color: @input-background-color;
-  &::-webkit-color-swatch-wrapper {
-    padding: 0;
-  }
+  &::-webkit-color-swatch-wrapper { padding: 0; }
   &::-webkit-color-swatch {
     border: 1px solid hsla(0,0%,0%,.2);
-    border-radius: 2em;
+    border-radius: 50%;
+    transition: transform .16s cubic-bezier(0.5, 0.15, 0.2, 1);
+    &:active {
+      transition-duration: 0s;
+      transform: scale(.9);
+    }
   }
 }
 
@@ -263,7 +273,7 @@
 // -------------------------
 
 .select {
-  height: calc(2em ~'+' 2px);
+  height: calc(@text-component-height ~'+' 2px); // + 2px? Magic!
   border-radius: @component-border-radius;
   border: 1px solid @button-border-color;
   background-color: @button-background-color;

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -15,7 +15,9 @@ input.input-checkbox,
 input.input-toggle {
   margin-top: 0; // Override Bootstrap's 4px
 }
-
+.input-label {
+  margin-bottom: 0;
+}
 
 //
 // Text Inputs
@@ -320,9 +322,6 @@ input.input-toggle {
 // -------------------------
 
 .input-label {
-  margin-right: 1em;
-
-  // layout child components
   .input-radio,
   .input-checkbox,
   .input-toggle {
@@ -331,37 +330,5 @@ input.input-toggle {
   }
   .input-toggle {
     margin-left: @component-margin-side; // For text on the left
-  }
-}
-
-
-//
-// Legend
-// -------------------------
-
-.input-legend {
-  margin: 0 0 .75em 0;
-  font-size: 1.25em;
-  color: @text-color-highlight;
-  border-bottom: 1px solid fade(@text-color-highlight, 8%);
-}
-
-
-//
-// Input Set
-// -------------------------
-
-.input-set {
-  & + & {
-    margin-top: 1.5em; // spacing between sets
-  }
-
-  .input-label {
-    display: block;
-    margin-right: 0;
-    width: -webkit-max-content; // Only stretch as needed since labels can't be clicked
-  }
-  .input-label + .input-label {
-    margin-top: .75em; // spacing between labels/rows
   }
 }

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -45,111 +45,6 @@ input.input-toggle {
 
 
 //
-// Text
-// -------------------------
-
-.input-text {
-  .input-block-mixin();
-  .input-field-mixin();
-}
-
-
-//
-// Search
-// -------------------------
-
-.input-search {
-  .input-block-mixin();
-  .input-field-mixin();
-  &&::-webkit-search-cancel-button {
-    -webkit-appearance: searchfield-cancel-button;
-  }
-}
-
-
-//
-// Text Area
-// -------------------------
-
-.input-textarea {
-  .input-block-mixin();
-  .input-field-mixin();
-}
-
-
-//
-// Number
-// -------------------------
-
-.input-number {
-  .input-field-mixin();
-  position: relative;
-  width: auto;
-  padding-right: 1.2em; // space for the spin button
-  &::-webkit-inner-spin-button {
-    -webkit-appearance: menulist-button;
-    position: absolute;
-    top: 1px;
-    bottom: 1px;
-    right: 1px;
-    width: calc(.6em ~'+' 9px); // magic numbers, OMG!
-    outline: 1px solid @input-background-color;
-    outline-offset: -1px; // reduces border radius (that can't be changed)
-    border-right: .2em solid @background-color-highlight; // a bit more padding
-    background-color: @background-color-highlight;
-    transition: transform .16s cubic-bezier(0.5, 0.15, 0.2, 1);
-    &:active {
-      transform: scale(.9);
-      transition-duration: 0s;
-    }
-  }
-}
-
-
-//
-// Radio
-// -------------------------
-
-.input-radio {
-  -webkit-appearance: none;
-  display: inline-block;
-  position: relative;
-  width: @component-size;
-  height: @component-size;
-  vertical-align: middle;
-  font-size: inherit;
-  border-radius: 50%;
-  background-color: @component-background-color;
-  transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
-
-  &:before {
-    content: "";
-    position: absolute;
-    width: inherit;
-    height: inherit;
-    border-radius: inherit;
-    border: @component-size/3 solid transparent;
-    background-clip: content-box;
-    background-color: @base-background-color;
-    transform: scale(0);
-    transition: transform .1s cubic-bezier(0.5, 0.15, 0.2, 1);
-  }
-  &&:focus {
-    outline: none;
-  }
-  &:active {
-    background-color: @background-color-info;
-  }
-  &:checked {
-    background-color: @background-color-info;
-    &:before {
-      transform: scale(1);
-    }
-  }
-}
-
-
-//
 // Checkbox
 // -------------------------
 
@@ -228,6 +123,192 @@ input.input-toggle {
 
 
 //
+// Color
+// -------------------------
+
+.input-color {
+  -webkit-appearance: none;
+  padding: 0;
+  width: @component-size * 2.5;
+  height: @component-size * 2.5;
+  vertical-align: middle;
+  border-radius: 50%;
+  border: 2px solid @input-border-color;
+  background-color: @input-background-color;
+  &::-webkit-color-swatch-wrapper { padding: 0; }
+  &::-webkit-color-swatch {
+    border: 1px solid hsla(0,0%,0%,.1);
+    border-radius: 50%;
+    transition: transform .16s cubic-bezier(0.5, 0.15, 0.2, 1);
+    &:active {
+      transition-duration: 0s;
+      transform: scale(.9);
+    }
+  }
+}
+
+
+//
+// Label
+// -------------------------
+
+.input-label {
+  .input-radio,
+  .input-checkbox,
+  .input-toggle {
+    margin-top: -.25em; // Vertical center (visually) - since most labels are upper case.
+    margin-right: @component-margin-side;
+  }
+  .input-toggle {
+    margin-left: @component-margin-side; // For text on the left
+  }
+}
+
+
+//
+// Number
+// -------------------------
+
+.input-number {
+  .input-field-mixin();
+  position: relative;
+  width: auto;
+  padding-right: 1.2em; // space for the spin button
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: menulist-button;
+    position: absolute;
+    top: 1px;
+    bottom: 1px;
+    right: 1px;
+    width: calc(.6em ~'+' 9px); // magic numbers, OMG!
+    outline: 1px solid @input-background-color;
+    outline-offset: -1px; // reduces border radius (that can't be changed)
+    border-right: .2em solid @background-color-highlight; // a bit more padding
+    background-color: @background-color-highlight;
+    transition: transform .16s cubic-bezier(0.5, 0.15, 0.2, 1);
+    &:active {
+      transform: scale(.9);
+      transition-duration: 0s;
+    }
+  }
+}
+
+
+//
+// Radio
+// -------------------------
+
+.input-radio {
+  -webkit-appearance: none;
+  display: inline-block;
+  position: relative;
+  width: @component-size;
+  height: @component-size;
+  vertical-align: middle;
+  font-size: inherit;
+  border-radius: 50%;
+  background-color: @component-background-color;
+  transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
+
+  &:before {
+    content: "";
+    position: absolute;
+    width: inherit;
+    height: inherit;
+    border-radius: inherit;
+    border: @component-size/3 solid transparent;
+    background-clip: content-box;
+    background-color: @base-background-color;
+    transform: scale(0);
+    transition: transform .1s cubic-bezier(0.5, 0.15, 0.2, 1);
+  }
+  &&:focus {
+    outline: none;
+  }
+  &:active {
+    background-color: @background-color-info;
+  }
+  &:checked {
+    background-color: @background-color-info;
+    &:before {
+      transform: scale(1);
+    }
+  }
+}
+
+
+//
+// Range (Slider)
+// -------------------------
+
+.input-range {
+  -webkit-appearance: none;
+  margin: @component-padding 0;
+  height: 4px;
+  border-radius: @component-border-radius;
+  background-color: @component-background-color;
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: @component-size;
+    height: @component-size;
+    border-radius: 50%;
+    background-color: @background-color-info;
+    transition: transform .16s;
+    &:active {
+      transition-duration: 0s;
+      transform: scale(.9);
+    }
+  }
+}
+
+
+//
+// Search
+// -------------------------
+
+.input-search {
+  .input-block-mixin();
+  .input-field-mixin();
+  &&::-webkit-search-cancel-button {
+    -webkit-appearance: searchfield-cancel-button;
+  }
+}
+
+
+//
+// Select
+// -------------------------
+
+.input-select {
+  height: calc(@text-component-height ~'+' 2px); // + 2px? Magic!
+  vertical-align: middle;
+  border-radius: @component-border-radius;
+  border: 1px solid @button-border-color;
+  background-color: @button-background-color;
+}
+
+
+//
+// Text
+// -------------------------
+
+.input-text {
+  .input-block-mixin();
+  .input-field-mixin();
+}
+
+
+//
+// Text Area
+// -------------------------
+
+.input-textarea {
+  .input-block-mixin();
+  .input-field-mixin();
+}
+
+
+//
 // Toggle
 // -------------------------
 
@@ -267,86 +348,5 @@ input.input-toggle {
   }
   &:checked:before {
     transform: translate3d(100%, 0, 0);
-  }
-}
-
-
-//
-// Slider
-// -------------------------
-
-.input-range {
-  -webkit-appearance: none;
-  margin: @component-padding 0;
-  height: 4px;
-  border-radius: @component-border-radius;
-  background-color: @component-background-color;
-  &::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    width: @component-size;
-    height: @component-size;
-    border-radius: 50%;
-    background-color: @background-color-info;
-    transition: transform .16s;
-    &:active {
-      transition-duration: 0s;
-      transform: scale(.9);
-    }
-  }
-}
-
-
-//
-// Color
-// -------------------------
-
-.input-color {
-  -webkit-appearance: none;
-  padding: 0;
-  width: @component-size * 2.5;
-  height: @component-size * 2.5;
-  vertical-align: middle;
-  border-radius: 50%;
-  border: 2px solid @input-border-color;
-  background-color: @input-background-color;
-  &::-webkit-color-swatch-wrapper { padding: 0; }
-  &::-webkit-color-swatch {
-    border: 1px solid hsla(0,0%,0%,.1);
-    border-radius: 50%;
-    transition: transform .16s cubic-bezier(0.5, 0.15, 0.2, 1);
-    &:active {
-      transition-duration: 0s;
-      transform: scale(.9);
-    }
-  }
-}
-
-
-//
-// Select
-// -------------------------
-
-.input-select {
-  height: calc(@text-component-height ~'+' 2px); // + 2px? Magic!
-  vertical-align: middle;
-  border-radius: @component-border-radius;
-  border: 1px solid @button-border-color;
-  background-color: @button-background-color;
-}
-
-
-//
-// Label
-// -------------------------
-
-.input-label {
-  .input-radio,
-  .input-checkbox,
-  .input-toggle {
-    margin-top: -.25em; // Vertical center (visually) - since most labels are upper case.
-    margin-right: @component-margin-side;
-  }
-  .input-toggle {
-    margin-left: @component-margin-side; // For text on the left
   }
 }

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -1,0 +1,270 @@
+@import "ui-variables";
+
+//
+// Text Inputs
+// -------------------------
+
+.input-text,
+.input-search,
+.input-number,
+.input-textarea {
+  width: 150px;
+  padding: @component-padding/4 @component-padding/2;
+  border-radius: @component-border-radius;
+  border: 1px solid @input-border-color;
+  background-color: @input-background-color;
+  &::-webkit-input-placeholder {
+    color: @text-color-subtle;
+  }
+  &:invalid {
+    color: @text-color-error;
+    border-color: @background-color-error;
+  }
+}
+
+
+//
+// Search
+// -------------------------
+
+.input-search {
+  &&::-webkit-search-cancel-button {
+    -webkit-appearance: searchfield-cancel-button;
+  }
+}
+
+
+//
+// Number
+// -------------------------
+
+.input-number {
+  width: auto;
+}
+
+
+//
+// Radio
+// -------------------------
+
+.input-radio {
+  -webkit-appearance: none;
+  display: inline-block;
+  position: relative;
+  width: 1.125em;
+  height: 1.125em;
+  margin: 0 .5em 0 0; // Bootstrap override
+  vertical-align: middle;
+  font-size: inherit;
+  border-radius: 1.125em;
+  background-color: @text-color-subtle;
+  transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
+
+  &:before {
+    content: "";
+    position: absolute;
+    width: inherit;
+    height: inherit;
+    border-radius: inherit;
+    background-color: @base-background-color;
+    transform: scale(0);
+    transition: transform .1s cubic-bezier(0.5, 0.15, 0.2, 1);
+  }
+  &&:focus {
+    outline: none;
+  }
+  &:active {
+    background-color: @background-color-info;
+  }
+  &:checked {
+    background-color: @background-color-info;
+    &:before {
+      transform: scale(.5);
+    }
+  }
+}
+
+
+//
+// Checkbox
+// -------------------------
+
+.input-checkbox {
+  -webkit-appearance: none;
+  display: inline-block;
+  position: relative;
+  width: 1.125em;
+  height: 1.125em;
+  margin: 0 .5em 0 0; // Bootstrap override
+  vertical-align: middle;
+  font-size: inherit;
+  border-radius: @component-border-radius;
+  background-color: @text-color-subtle;
+  transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
+
+  &:focus {
+    outline: 0;
+    box-shadow: 0 0 0 1px @base-border-color;
+  }
+  &:active {
+    background-color: @background-color-info;
+  }
+
+  &:before,
+  &:after {
+    content: "";
+    position: absolute;
+    top: .85em;
+    left: .425em;
+    height: .125em;
+    min-height: 2px;
+    max-height: 5px;
+    border-radius: 1px;
+    background-color: @base-background-color;
+    transform-origin: 0 0;
+    opacity: 0;
+    transition: transform .1s cubic-bezier(0.5, 0.15, 0.2, 1), opacity .1s cubic-bezier(0.5, 0.15, 0.2, 1);
+  }
+  &:before {
+    width: .35em;
+    transform: translate3d(0,0,0) rotate(225deg) scale(0);
+  }
+  &:after {
+    width: .7em;
+    margin: -1px;
+    transform: translate3d(0,0,0) rotate(-45deg) scale(0);
+    transition-delay: .05s;
+  }
+
+  &:checked {
+    background-color: @background-color-info;
+    &:active {
+      background-color: @text-color-subtle;
+    }
+    &:before {
+      opacity: 1;
+      transform: translate3d(0,0,0) rotate(225deg) scale(1);
+      transition-delay: .05s;
+    }
+    &:after {
+      opacity: 1;
+      transform: translate3d(0, 0, 0) rotate(-45deg) scale(1);
+      transition-delay: 0;
+    }
+  }
+
+  &:indeterminate {
+    background-color: @background-color-info;
+    &:active {
+      background-color: @text-color-subtle;
+    }
+    &:after {
+      opacity: 1;
+      transform: translate3d(-.125em, -.25em, 0) rotate(0deg) scale(1);
+      transition-delay: 0;
+    }
+  }
+}
+
+
+//
+// Toggle
+// -------------------------
+
+.input-toggle {
+  -webkit-appearance: none;
+  display: inline-block;
+  position: relative;
+  font-size: inherit;
+  margin: 0 0 0 -3.5em;
+  width: 2.8em;
+  height: 1.4em;
+  border-radius: 2em;
+  background-color: @text-color-subtle;
+  transition: background-color 0.2s cubic-bezier(0.5, 0.15, 0.2, 1);
+  &.input-toggle:focus {
+    outline: 0;
+  }
+  &:checked {
+    background-color: @background-color-info;
+  }
+
+  // Thumb
+  &:before {
+    content: "";
+    position: absolute;
+    width: 1.4em;
+    height: inherit;
+    border-radius: inherit;
+    border: 4px solid transparent;
+    background-clip: content-box;
+    background-color: @base-background-color;
+    transition: transform 0.2s cubic-bezier(0.5, 0.15, 0.2, 1);
+  }
+  &:active:before {
+    opacity: .5;
+  }
+  &:checked:before {
+    transform: translate3d(100%, 0, 0);
+  }
+}
+
+
+//
+// Slider
+// -------------------------
+
+.input-range {
+  -webkit-appearance: none;
+  margin: @component-padding 0;
+  height: 4px;
+  border-radius: @component-border-radius;
+  border: 1px solid @input-border-color;
+  background-color: @input-background-color;
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 1.25em;
+    height: 1.25em;
+    border-radius: 1em;
+    background-color: @background-color-info;
+    transition: transform .16s;
+    &:active {
+      transition-duration: 0s;
+      transform: scale(.9);
+    }
+  }
+}
+
+
+//
+// Color
+// -------------------------
+
+.input-color {
+  -webkit-appearance: none;
+  padding: 4px;
+  width: 3em;
+  height: 3em;
+  border-radius: 3em;
+  border: 1px solid @input-border-color;
+  background-color: @input-background-color;
+  &::-webkit-color-swatch-wrapper {
+    padding: 0;
+  }
+  &::-webkit-color-swatch {
+    border: 1px solid hsla(0,0%,0%,.2);
+    border-radius: 2em;
+  }
+}
+
+
+//
+// Select
+// -------------------------
+
+.select {
+  height: calc(2em ~'+' 2px);
+  border-radius: @component-border-radius;
+  border: 1px solid @button-border-color;
+  background-color: @button-background-color;
+}

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -1,8 +1,21 @@
 @import "ui-variables";
 
 @component-size: @component-icon-size; // use for text-less controls like radio, checkboxes etc.
+@component-margin-side: .3em;
 @text-component-height: 2em;
 @component-background-color: mix(@text-color, @base-background-color, 20%);
+
+
+//
+// Overrides
+// -------------------------
+
+input.input-radio,
+input.input-checkbox,
+input.input-toggle {
+  margin-top: 0; // Override Bootstrap's 4px
+}
+
 
 //
 // Text Inputs
@@ -10,9 +23,15 @@
 
 .input-text,
 .input-search,
+.input-textarea {
+  display: block;
+  width: 100%;
+}
+
+.input-text,
+.input-search,
 .input-number,
 .input-textarea {
-  width: 150px;
   padding: .25em .4em;
   line-height: 1.5; // line-height + padding = @text-component-height
   border-radius: @component-border-radius;
@@ -83,8 +102,6 @@
   background-color: @component-background-color;
   transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
 
-  && { margin: 0 .5em 0 0; } // override bootstrap
-
   &:before {
     content: "";
     position: absolute;
@@ -127,8 +144,6 @@
   border-radius: @component-border-radius;
   background-color: @component-background-color;
   transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
-
-  && { margin: 0 .5em 0 0; } // override bootstrap
 
   &&:focus {
     outline: 0; // TODO: Add it back
@@ -203,11 +218,10 @@
   font-size: inherit;
   width: @component-size * 2;
   height: @component-size;
+  vertical-align: middle;
   border-radius: 2em;
   background-color: @component-background-color;
   transition: background-color .2s cubic-bezier(0.5, 0.15, 0.2, 1);
-
-  && { margin: 0; } // override bootstrap
 
   &&:focus {
     outline: 0;
@@ -271,6 +285,7 @@
   padding: 0;
   width: @component-size * 2.5;
   height: @component-size * 2.5;
+  vertical-align: middle;
   border-radius: 50%;
   border: 2px solid @input-border-color;
   background-color: @input-background-color;
@@ -293,7 +308,60 @@
 
 .input-select {
   height: calc(@text-component-height ~'+' 2px); // + 2px? Magic!
+  vertical-align: middle;
   border-radius: @component-border-radius;
   border: 1px solid @button-border-color;
   background-color: @button-background-color;
+}
+
+
+//
+// Label
+// -------------------------
+
+.input-label {
+  margin-right: 1em;
+
+  // layout child components
+  .input-radio,
+  .input-checkbox,
+  .input-toggle {
+    margin-top: -.25em; // Vertical center (visually) - since most labels are upper case.
+    margin-right: @component-margin-side;
+  }
+  .input-toggle {
+    margin-left: @component-margin-side; // For text on the left
+  }
+}
+
+
+//
+// Legend
+// -------------------------
+
+.input-legend {
+  margin: 0 0 .75em 0;
+  font-size: 1.25em;
+  color: @text-color-highlight;
+  border-bottom: 1px solid fade(@text-color-highlight, 8%);
+}
+
+
+//
+// Input Set
+// -------------------------
+
+.input-set {
+  & + & {
+    margin-top: 1.5em; // spacing between sets
+  }
+
+  .input-label {
+    display: block;
+    margin-right: 0;
+    width: -webkit-max-content; // Only stretch as needed since labels can't be clicked
+  }
+  .input-label + .input-label {
+    margin-top: .75em; // spacing between labels/rows
+  }
 }

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -44,7 +44,19 @@
 // -------------------------
 
 .input-number {
+  position: relative;
   width: auto;
+  padding-right: 20px; // space for the spin-button
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: menulist;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    width: 16px;
+    border-right: 4px solid @input-background-color; // a bit more padding
+    background-color: @input-background-color;
+  }
 }
 
 


### PR DESCRIPTION
This adds a few commonly used inputs and other controls:
- [x] `input-text`
- [x] `input-search`
- [x] `input-textarea`
- [x] `input-radio`
- [x] `input-checkbox`
- [x] `input-toggle`
- [x] `input-range`
- [x] `input-color`
- [x] `input-number`
- [x] `input-select`
- [x] `input-label`

![inputs](https://cloud.githubusercontent.com/assets/378023/16706747/c93b126e-45f2-11e6-9d89-aec748c163bf.gif)

Some things to decide:
- [x] Class names. Once it's out, it will have to stay till the next major version.
- [x] Sizes. I tried to use `em`s, but running into same [pixel snapping](https://github.com/atom/one-dark-ui/pull/144#issuecomment-227700428) issues. Might give up and just use fixed `px`s. :sob:

/cc @atom/design 
