### PR TITLE
Let themes opt-out of custom control styling

### DIFF
--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -49,74 +49,77 @@ input.input-toggle {
 // -------------------------
 
 .input-checkbox {
-  -webkit-appearance: none;
-  display: inline-block;
-  position: relative;
-  width: @component-size;
-  height: @component-size;
   vertical-align: middle;
-  font-size: inherit;
-  border-radius: @component-border-radius;
-  background-color: @component-background-color;
-  transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
 
-  &&:focus {
-    outline: 0; // TODO: Add it back
-  }
-  &:active {
-    background-color: @background-color-info;
-  }
+  & when (@use-custom-controls) {
+    -webkit-appearance: none;
+    display: inline-block;
+    position: relative;
+    width: @component-size;
+    height: @component-size;
+    font-size: inherit;
+    border-radius: @component-border-radius;
+    background-color: @component-background-color;
+    transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
 
-  &:before,
-  &:after {
-    content: "";
-    position: absolute;
-    top: @component-size * .75;
-    left: @component-size * .4;
-    height: 2px;
-    border-radius: 1px;
-    background-color: @base-background-color;
-    transform-origin: 0 0;
-    opacity: 0;
-    transition: transform .1s cubic-bezier(0.5, 0.15, 0.2, 1), opacity .1s cubic-bezier(0.5, 0.15, 0.2, 1);
-  }
-  &:before {
-    width: @component-size * .33;
-    transform: translate3d(0,0,0) rotate(225deg) scale(0);
-  }
-  &:after {
-    width: @component-size * .66;
-    margin: -1px;
-    transform: translate3d(0,0,0) rotate(-45deg) scale(0);
-    transition-delay: .05s;
-  }
-
-  &:checked {
-    background-color: @background-color-info;
+    &&:focus {
+      outline: 0; // TODO: Add it back
+    }
     &:active {
-      background-color: @component-background-color;
+      background-color: @background-color-info;
+    }
+
+    &:before,
+    &:after {
+      content: "";
+      position: absolute;
+      top: @component-size * .75;
+      left: @component-size * .4;
+      height: 2px;
+      border-radius: 1px;
+      background-color: @base-background-color;
+      transform-origin: 0 0;
+      opacity: 0;
+      transition: transform .1s cubic-bezier(0.5, 0.15, 0.2, 1), opacity .1s cubic-bezier(0.5, 0.15, 0.2, 1);
     }
     &:before {
-      opacity: 1;
-      transform: translate3d(0,0,0) rotate(225deg) scale(1);
+      width: @component-size * .33;
+      transform: translate3d(0,0,0) rotate(225deg) scale(0);
+    }
+    &:after {
+      width: @component-size * .66;
+      margin: -1px;
+      transform: translate3d(0,0,0) rotate(-45deg) scale(0);
       transition-delay: .05s;
     }
-    &:after {
-      opacity: 1;
-      transform: translate3d(0, 0, 0) rotate(-45deg) scale(1);
-      transition-delay: 0;
-    }
-  }
 
-  &:indeterminate {
-    background-color: @background-color-info;
-    &:active {
-      background-color: @component-background-color;
+    &:checked {
+      background-color: @background-color-info;
+      &:active {
+        background-color: @component-background-color;
+      }
+      &:before {
+        opacity: 1;
+        transform: translate3d(0,0,0) rotate(225deg) scale(1);
+        transition-delay: .05s;
+      }
+      &:after {
+        opacity: 1;
+        transform: translate3d(0, 0, 0) rotate(-45deg) scale(1);
+        transition-delay: 0;
+      }
     }
-    &:after {
-      opacity: 1;
-      transform: translate3d(@component-size * -.14, @component-size * -.25, 0) rotate(0deg) scale(1);
-      transition-delay: 0;
+
+    &:indeterminate {
+      background-color: @background-color-info;
+      &:active {
+        background-color: @component-background-color;
+      }
+      &:after {
+        opacity: 1;
+        transform: translate3d(@component-size * -.14, @component-size * -.25, 0) rotate(0deg) scale(1);
+        transition-delay: 0;
+      }
     }
   }
 }
@@ -126,26 +129,31 @@ input.input-toggle {
 // Color
 // -------------------------
 
+
 .input-color {
-  -webkit-appearance: none;
-  padding: 0;
-  width: @component-size * 2.5;
-  height: @component-size * 2.5;
   vertical-align: middle;
-  border-radius: 50%;
-  border: 2px solid @input-border-color;
-  background-color: @input-background-color;
-  &::-webkit-color-swatch-wrapper { padding: 0; }
-  &::-webkit-color-swatch {
-    border: 1px solid hsla(0,0%,0%,.1);
+
+  & when (@use-custom-controls) {
+    -webkit-appearance: none;
+    padding: 0;
+    width: @component-size * 2.5;
+    height: @component-size * 2.5;
     border-radius: 50%;
-    transition: transform .16s cubic-bezier(0.5, 0.15, 0.2, 1);
-    &:active {
-      transition-duration: 0s;
-      transform: scale(.9);
+    border: 2px solid @input-border-color;
+    background-color: @input-background-color;
+    &::-webkit-color-swatch-wrapper { padding: 0; }
+    &::-webkit-color-swatch {
+      border: 1px solid hsla(0,0%,0%,.1);
+      border-radius: 50%;
+      transition: transform .16s cubic-bezier(0.5, 0.15, 0.2, 1);
+      &:active {
+        transition-duration: 0s;
+        transform: scale(.9);
+      }
     }
   }
 }
+
 
 
 //
@@ -170,25 +178,29 @@ input.input-toggle {
 // -------------------------
 
 .input-number {
-  .input-field-mixin();
-  position: relative;
-  width: auto;
-  padding-right: 1.2em; // space for the spin button
-  &::-webkit-inner-spin-button {
-    -webkit-appearance: menulist-button;
-    position: absolute;
-    top: 1px;
-    bottom: 1px;
-    right: 1px;
-    width: calc(.6em ~'+' 9px); // magic numbers, OMG!
-    outline: 1px solid @input-background-color;
-    outline-offset: -1px; // reduces border radius (that can't be changed)
-    border-right: .2em solid @background-color-highlight; // a bit more padding
-    background-color: @background-color-highlight;
-    transition: transform .16s cubic-bezier(0.5, 0.15, 0.2, 1);
-    &:active {
-      transform: scale(.9);
-      transition-duration: 0s;
+  vertical-align: middle;
+
+  & when (@use-custom-controls) {
+    .input-field-mixin();
+    position: relative;
+    width: auto;
+    padding-right: 1.2em; // space for the spin button
+    &::-webkit-inner-spin-button {
+      -webkit-appearance: menulist-button;
+      position: absolute;
+      top: 1px;
+      bottom: 1px;
+      right: 1px;
+      width: calc(.6em ~'+' 9px); // magic numbers, OMG!
+      outline: 1px solid @input-background-color;
+      outline-offset: -1px; // reduces border radius (that can't be changed)
+      border-right: .2em solid @background-color-highlight; // a bit more padding
+      background-color: @background-color-highlight;
+      transition: transform .16s cubic-bezier(0.5, 0.15, 0.2, 1);
+      &:active {
+        transform: scale(.9);
+        transition-duration: 0s;
+      }
     }
   }
 }
@@ -199,39 +211,42 @@ input.input-toggle {
 // -------------------------
 
 .input-radio {
-  -webkit-appearance: none;
-  display: inline-block;
-  position: relative;
-  width: @component-size;
-  height: @component-size;
   vertical-align: middle;
-  font-size: inherit;
-  border-radius: 50%;
-  background-color: @component-background-color;
-  transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
 
-  &:before {
-    content: "";
-    position: absolute;
-    width: inherit;
-    height: inherit;
-    border-radius: inherit;
-    border: @component-size/3 solid transparent;
-    background-clip: content-box;
-    background-color: @base-background-color;
-    transform: scale(0);
-    transition: transform .1s cubic-bezier(0.5, 0.15, 0.2, 1);
-  }
-  &&:focus {
-    outline: none;
-  }
-  &:active {
-    background-color: @background-color-info;
-  }
-  &:checked {
-    background-color: @background-color-info;
+  & when (@use-custom-controls) {
+    -webkit-appearance: none;
+    display: inline-block;
+    position: relative;
+    width: @component-size;
+    height: @component-size;
+    font-size: inherit;
+    border-radius: 50%;
+    background-color: @component-background-color;
+    transition: background-color .16s cubic-bezier(0.5, 0.15, 0.2, 1);
+
     &:before {
-      transform: scale(1);
+      content: "";
+      position: absolute;
+      width: inherit;
+      height: inherit;
+      border-radius: inherit;
+      border: @component-size/3 solid transparent;
+      background-clip: content-box;
+      background-color: @base-background-color;
+      transform: scale(0);
+      transition: transform .1s cubic-bezier(0.5, 0.15, 0.2, 1);
+    }
+    &&:focus {
+      outline: none;
+    }
+    &:active {
+      background-color: @background-color-info;
+    }
+    &:checked {
+      background-color: @background-color-info;
+      &:before {
+        transform: scale(1);
+      }
     }
   }
 }
@@ -242,21 +257,23 @@ input.input-toggle {
 // -------------------------
 
 .input-range {
-  -webkit-appearance: none;
-  margin: @component-padding 0;
-  height: 4px;
-  border-radius: @component-border-radius;
-  background-color: @component-background-color;
-  &::-webkit-slider-thumb {
+  & when (@use-custom-controls) {
     -webkit-appearance: none;
-    width: @component-size;
-    height: @component-size;
-    border-radius: 50%;
-    background-color: @background-color-info;
-    transition: transform .16s;
-    &:active {
-      transition-duration: 0s;
-      transform: scale(.9);
+    margin: @component-padding 0;
+    height: 4px;
+    border-radius: @component-border-radius;
+    background-color: @component-background-color;
+    &::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      width: @component-size;
+      height: @component-size;
+      border-radius: 50%;
+      background-color: @background-color-info;
+      transition: transform .16s;
+      &:active {
+        transition-duration: 0s;
+        transform: scale(.9);
+      }
     }
   }
 }
@@ -268,9 +285,12 @@ input.input-toggle {
 
 .input-search {
   .input-block-mixin();
-  .input-field-mixin();
   &&::-webkit-search-cancel-button {
     -webkit-appearance: searchfield-cancel-button;
+  }
+
+  & when (@use-custom-controls) {
+    .input-field-mixin();
   }
 }
 
@@ -280,11 +300,14 @@ input.input-toggle {
 // -------------------------
 
 .input-select {
-  height: calc(@text-component-height ~'+' 2px); // + 2px? Magic!
   vertical-align: middle;
-  border-radius: @component-border-radius;
-  border: 1px solid @button-border-color;
-  background-color: @button-background-color;
+
+  & when (@use-custom-controls) {
+    height: calc(@text-component-height ~'+' 2px); // + 2px? Magic!
+    border-radius: @component-border-radius;
+    border: 1px solid @button-border-color;
+    background-color: @button-background-color;
+  }
 }
 
 
@@ -294,7 +317,10 @@ input.input-toggle {
 
 .input-text {
   .input-block-mixin();
-  .input-field-mixin();
+
+  & when (@use-custom-controls) {
+    .input-field-mixin();
+  }
 }
 
 
@@ -304,7 +330,10 @@ input.input-toggle {
 
 .input-textarea {
   .input-block-mixin();
-  .input-field-mixin();
+
+  & when (@use-custom-controls) {
+    .input-field-mixin();
+  }
 }
 
 
@@ -313,40 +342,42 @@ input.input-toggle {
 // -------------------------
 
 .input-toggle {
-  -webkit-appearance: none;
-  display: inline-block;
-  position: relative;
-  font-size: inherit;
-  width: @component-size * 2;
-  height: @component-size;
-  vertical-align: middle;
-  border-radius: 2em;
-  background-color: @component-background-color;
-  transition: background-color .2s cubic-bezier(0.5, 0.15, 0.2, 1);
-
-  &&:focus {
-    outline: 0;
-  }
-  &:checked {
-    background-color: @background-color-info;
-  }
-
-  // Thumb
-  &:before {
-    content: "";
-    position: absolute;
-    width: @component-size;
+  & when (@use-custom-controls) {
+    -webkit-appearance: none;
+    display: inline-block;
+    position: relative;
+    font-size: inherit;
+    width: @component-size * 2;
     height: @component-size;
-    border-radius: inherit;
-    border: @component-size/4 solid transparent;
-    background-clip: content-box;
-    background-color: @base-background-color;
-    transition: transform .2s cubic-bezier(0.5, 0.15, 0.2, 1);
-  }
-  &:active:before {
-    opacity: .5;
-  }
-  &:checked:before {
-    transform: translate3d(100%, 0, 0);
+    vertical-align: middle;
+    border-radius: 2em;
+    background-color: @component-background-color;
+    transition: background-color .2s cubic-bezier(0.5, 0.15, 0.2, 1);
+
+    &&:focus {
+      outline: 0;
+    }
+    &:checked {
+      background-color: @background-color-info;
+    }
+
+    // Thumb
+    &:before {
+      content: "";
+      position: absolute;
+      width: @component-size;
+      height: @component-size;
+      border-radius: inherit;
+      border: @component-size/4 solid transparent;
+      background-clip: content-box;
+      background-color: @base-background-color;
+      transition: transform .2s cubic-bezier(0.5, 0.15, 0.2, 1);
+    }
+    &:active:before {
+      opacity: .5;
+    }
+    &:checked:before {
+      transform: translate3d(100%, 0, 0);
+    }
   }
 }

--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -167,9 +167,6 @@ input.input-toggle {
     margin-top: -.25em; // Vertical center (visually) - since most labels are upper case.
     margin-right: @component-margin-side;
   }
-  .input-toggle {
-    margin-left: @component-margin-side; // For text on the left
-  }
 }
 
 


### PR DESCRIPTION
⚠️  Depends on https://github.com/atom/atom/pull/12150

This wraps all the custom styling inside a guard so that themes can opt-out if prefered. It's implemented as:

``` less
.component {
  // some default styles

  & when (@use-custom-controls) {
    // custom styles
  }
}
```

Closes #10
