### PR TITLE
Limit custom number arrows to macOS only

### DIFF
--- a/styles/inputs.less
+++ b/styles/inputs.less
@@ -181,22 +181,24 @@ input.input-toggle {
     .input-field-mixin();
     position: relative;
     width: auto;
-    padding-right: 1.2em; // space for the spin button
-    &::-webkit-inner-spin-button {
-      -webkit-appearance: menulist-button;
-      position: absolute;
-      top: 1px;
-      bottom: 1px;
-      right: 1px;
-      width: calc(.6em ~'+' 9px); // magic numbers, OMG!
-      outline: 1px solid @input-background-color;
-      outline-offset: -1px; // reduces border radius (that can't be changed)
-      border-right: .2em solid @background-color-highlight; // a bit more padding
-      background-color: @background-color-highlight;
-      transition: transform .16s cubic-bezier(0.5, 0.15, 0.2, 1);
-      &:active {
-        transform: scale(.9);
-        transition-duration: 0s;
+    .platform-darwin & {
+      padding-right: 1.2em; // space for the spin button
+      &::-webkit-inner-spin-button {
+        -webkit-appearance: menulist-button;
+        position: absolute;
+        top: 1px;
+        bottom: 1px;
+        right: 1px;
+        width: calc(.6em ~'+' 9px); // magic numbers, OMG!
+        outline: 1px solid @input-background-color;
+        outline-offset: -1px; // reduces border radius (that can't be changed)
+        border-right: .2em solid @background-color-highlight; // a bit more padding
+        background-color: @background-color-highlight;
+        transition: transform .16s cubic-bezier(0.5, 0.15, 0.2, 1);
+        &:active {
+          transform: scale(.9);
+          transition-duration: 0s;
+        }
       }
     }
   }


### PR DESCRIPTION
Since on other platforms it’s just a down arrow.

Fixes #9
