### PR TITLE
More components

### DIFF
--- a/atom-ui.less
+++ b/atom-ui.less
@@ -28,8 +28,11 @@
 @import "styles/loading.less";
 @import "styles/messages.less";
 @import "styles/modals.less";
+@import "styles/nav.less";
 @import "styles/panels.less";
 @import "styles/select-list.less";
 @import "styles/site-colors.less";
+@import "styles/table.less";
 @import "styles/text.less";
+@import "styles/toolbar.less";
 @import "styles/tooltip.less";

--- a/styles/nav.less
+++ b/styles/nav.less
@@ -1,0 +1,208 @@
+@import "ui-variables";
+
+//
+// Breadcrumbs
+// --------------------------------
+
+.breadcrumbs {
+  -webkit-user-select: none;
+  cursor: default;
+}
+
+.breadcrumbs-item {
+  display: inline-block;
+  color: @text-color-subtle;
+
+
+  // active
+  &:hover,
+  &:last-child {
+    color: @text-color-selected;
+  }
+  &:active {
+    color: @text-color-subtle;
+  }
+
+  // dividers
+  & + .breadcrumbs-item::before {
+    content: "";
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0 1em;
+    height: 2em;
+    transform: rotate(15deg);
+    border-left: 1px solid @base-border-color;
+  }
+}
+
+
+//
+// Nav
+// --------------------------------
+
+.a-nav {
+  display: flex;
+  white-space: nowrap;
+  overflow-x: auto;
+  -webkit-user-select: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.a-nav-item {
+  flex: 1;
+  color: @text-color-subtle;
+  border: 1px solid @base-border-color;
+  border-width: 0 0 1px 0;
+  line-height: 1;
+  text-align: center;
+  padding: @component-padding*0.75 @component-padding;
+  cursor: default;
+
+  &:hover {
+    color: @text-color-highlight;
+  }
+  &:active,
+  &.selected {
+    color: @text-color-selected;
+    border-color: @text-color-subtle;
+  }
+}
+
+// Vertical -------------
+
+.a-nav--vertical {
+  overflow: auto;
+  flex-direction: column;
+
+  .a-nav-item {
+    text-align: left;
+    border-width: 0 0 0 1px;
+  }
+}
+
+
+
+
+//
+// Panel
+// --------------------------------
+
+
+.a-panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  -webkit-user-select: none;
+
+  .a-panel-heading {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: stretch;
+    padding: 0;
+    cursor: default;
+    box-shadow: inset 0 -1px 0 @base-border-color;
+    background-color: @tool-panel-background-color;
+  }
+
+  .a-panel-nav {
+    flex: 1;
+    display: flex;
+    padding: 0;
+    white-space: nowrap;
+    overflow-x: auto;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+  .a-panel-nav-item {
+    color: @text-color-subtle;
+    border: 1px solid transparent;
+    border-width: 0 1px;
+    line-height: 1;
+    text-align: center;
+    padding: @component-padding*0.75 @component-padding;
+
+    &:hover {
+      color: @text-color-highlight;
+    }
+    &:active,
+    &.selected {
+      color: @text-color-selected;
+      border-color: @base-border-color;
+      background-color: @base-background-color;
+      &:first-child {
+        border-left-color: transparent;
+      }
+    }
+  }
+
+  .a-panel-icon-button {
+    color: inherit;
+    padding: 0 @component-padding/2;
+    min-width: 2em;
+    border: none;
+    border-left: 1px solid @base-border-color;
+    background-color: transparent;
+    cursor: default;
+    &:hover {
+      color: @text-color-highlight;
+    }
+    &:active {
+      color: @text-color-subtle;
+    }
+    &:before {
+      margin-right: 0;
+    }
+  }
+
+  .a-panel-body {
+    position: relative;
+    overflow: auto;
+    flex: 1;
+    min-height: 0;
+    background-color: @base-background-color;
+    -webkit-user-select: text;
+  }
+}
+
+// Vertical -------------
+
+.a-panel--vertical {
+  flex-direction: row;
+
+  .a-panel-heading {
+    flex-direction: column;
+    box-shadow: inset -1px 0 0 @base-border-color;
+  }
+
+  .a-panel-nav {
+    flex-direction: column;
+  }
+
+  .a-panel-nav-item {
+    border-width: 1px 0;
+
+    &:active,
+    &.selected {
+      &:first-child {
+        border-top-color: transparent;
+      }
+    }
+
+    &.icon::before {
+      margin-right: 0;
+    }
+  }
+
+  .a-panel-icon-button {
+    color: inherit;
+    padding: @component-padding/2 0;
+    min-width: 0;
+    min-height: 2em;
+    border: none;
+    border-top: 1px solid @base-border-color;
+  }
+}

--- a/styles/table.less
+++ b/styles/table.less
@@ -1,0 +1,23 @@
+@import "ui-variables";
+
+//
+// Table
+// --------------------------------
+
+.a-table {
+  width: 100%;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.a-table-header {
+  border-bottom: 1px solid @base-border-color;
+}
+
+.a-table-row:nth-child(odd) {
+  background-color: @background-color-highlight;
+}
+
+.a-table-cell {
+  padding: @component-padding/2 @component-padding;
+}

--- a/styles/toolbar.less
+++ b/styles/toolbar.less
@@ -1,0 +1,21 @@
+@import "ui-variables";
+
+//
+// Toolbar
+// --------------------------------
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  padding: @component-padding / 2;
+}
+
+.toolbar-item {
+  margin: @component-padding / 2;
+}
+
+.toolbar-item.flexible {
+  flex: 1;
+}


### PR DESCRIPTION
This PR adds a few more components

- [x] Navigation
  - [x] Breadcrumbs
  - [x] Simple nav
  - [x] Panel with multiple tabs
- [x] Table
- [x] Toolbar

![screen shot 2017-02-17 at 7 30 17 pm](https://cloud.githubusercontent.com/assets/378023/23062051/998b4688-f547-11e6-8ee7-424304d90340.png)


## Benefits

Helps package authors with their styling needs.


## Concerns

Mostly maintenance cost. Also there is a risk of class name clashing:

- For example `.breadcrumbs` isn't used by any bundled packages. But there is still a chance that some of the thousands of community packages use it. Same with `.toolbar`.
- `.nav` is used in the settings-view and `.table` in Nuclide. So those two components got prefixed with `a-`. Short for `atom-`. Feels inconsistent, but there is currently no other way without breaking existing packages. Alternatives to `.a-table` could be:
  - `.atom-table`
  - `.atom-ui-table` (this package's name)
  - `.core-table` (meaning it gets bundled)


## Relevant Issues

Continues improving https://github.com/atom/atom-ui/issues/13

/cc @atom/design